### PR TITLE
Nette 2.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
 
 	"require": {
 		"php"			: ">=5.3.2",
-		"nette/nette"	: "2.1@dev",
+		"nette/nette"	: "2.1@dev"
 	},
 
 	"autoload": {

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
 
 	"require": {
 		"php"			: ">=5.3.2",
-		"nette/nette"	: "*"
+		"nette/nette"	: "2.1@dev",
 	},
 
 	"autoload": {

--- a/readme.md
+++ b/readme.md
@@ -10,16 +10,15 @@ The best way to install ipub/gravatar is using  [Composer](http://getcomposer.or
 ```json
 {
 	"require": {
-		"ipub/gravatar": "dev-master"
+		"ipub/gravatar": "dev-nette-2.1"
 	}
 }
 ```
 
 or
 
-
 ```sh
-$ composer require ipub/gravatar:@dev
+$ composer require ipub/gravatar:@dev-nette-2.1
 ```
 
 After that you have to register extension in config.neon.


### PR DESCRIPTION
Invoking filters via $template->getGravatarService($vars) is deprecated, use ($vars|getGravatarService)

Macros.php:
- Line 60: return $writer->write('echo %escape($template->getGravatarService()->buildUrl('. $arguments['email'] .', '. $arguments['size'] .'))');
- Line 79: return $writer->write('?> '. ($node->htmlNode->name === 'a' ? 'href' : 'src') .'="<?php echo %escape($template->getGravatarService()->buildUrl('. $arguments['email'] .', '. $arguments['size'] .'))?>" <?php');

Nette forum: https://forum.nette.org/cs/26650-ipublikuj-gravatar-a-nette-2-4
Partial solution from user "emptywall":
- return $writer->write('echo %escape(call_user_func($this->filters->getGravatarService()->buildUrl(), $arguments["email"], $arguments["size"]))');
- return $writer->write('?> '. ($node->htmlNode->name === 'a' ? 'href' : 'src') .'="<?php echo %escape(call_user_func($this->filters->getGravatarService()->buildUrl(), $arguments["email"], $arguments["size"]))?>" <?php');

Error after partial solution:
Fatal Error
Call to undefined method Latte\Runtime\FilterExecutor::getGravatarService()
<img class="user-image" alt="User Image" src="<?php echo LR\Filters::escapeHtmlAttr(call_user_func($this->filters->getGravatarService()->buildUrl($arguments["email"], $arguments["size"])))?>" >