### PR TITLE
Use Nette\SmartObject to fix PHP 7.2 compability

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,8 @@ env:
 
 php:
   - 7.0
+  - 7.1
+  - 7.2
 
 before_install:
   - composer self-update

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: php
 
 env:
   - NETTE=default
-  - NETTE=~2.3.0
 
 php:
   - 7.0

--- a/composer.json
+++ b/composer.json
@@ -32,12 +32,12 @@
 	"require": {
 		"php"	: ">=7.0.0",
 
-		"nette/application"	: "~2.3",
-		"nette/di"			: "~2.3",
-		"nette/http"		: "~2.3",
-		"nette/utils"		: "~2.3",
+		"nette/application"	: "~2.4",
+		"nette/di"			: "~2.4",
+		"nette/http"		: "~2.4",
+		"nette/utils"		: "~2.4",
 
-		"latte/latte"	: "~2.3",
+		"latte/latte"	: "~2.4",
 
 		"pds/skeleton"	: "@dev"
 	},

--- a/src/IPub/Gravatar/Application/GravatarResponse.php
+++ b/src/IPub/Gravatar/Application/GravatarResponse.php
@@ -32,8 +32,10 @@ use IPub\Gravatar\Exceptions;
  *
  * @author         Adam Kadlec <adam.kadlec@ipublikuj.eu>
  */
-final class GravatarResponse extends Nette\Object implements Nette\Application\IResponse
+final class GravatarResponse implements Nette\Application\IResponse
 {
+	use Nette\SmartObject;
+
 	/**
 	 * @var Utils\Image
 	 */

--- a/src/IPub/Gravatar/Gravatar.php
+++ b/src/IPub/Gravatar/Gravatar.php
@@ -33,8 +33,9 @@ use IPub\Gravatar\Templating;
  *
  * @author         Adam Kadlec <adam.kadlec@ipublikuj.eu>
  */
-final class Gravatar extends Nette\Object
+final class Gravatar
 {
+	use Nette\SmartObject;
 	/**
 	 * @var string - URL constants for the avatar images
 	 */

--- a/src/IPub/Gravatar/Gravatar.php
+++ b/src/IPub/Gravatar/Gravatar.php
@@ -36,6 +36,7 @@ use IPub\Gravatar\Templating;
 final class Gravatar
 {
 	use Nette\SmartObject;
+	
 	/**
 	 * @var string - URL constants for the avatar images
 	 */

--- a/src/IPub/Gravatar/Templating/Helpers.php
+++ b/src/IPub/Gravatar/Templating/Helpers.php
@@ -30,8 +30,10 @@ use IPub\Gravatar;
  *
  * @author         Adam Kadlec <adam.kadlec@ipublikuj.eu>
  */
-final class Helpers extends Nette\Object
+final class Helpers
 {
+	use Nette\SmartObject;
+
 	/**
 	 * @var Gravatar\Gravatar
 	 */


### PR DESCRIPTION
  Compability with PHP 7.2, sadly this means to drop nette 2.3 compability :cry: 